### PR TITLE
feat: in-app review prompt após registrar doação

### DIFF
--- a/components/donation/Card.vue
+++ b/components/donation/Card.vue
@@ -112,7 +112,9 @@
 
 <script setup lang="ts">
 import { useUserStore } from "@/stores/user";
+import { useAppReview } from "@/composables/useAppReview";
 const userStore = useUserStore();
+const { scheduleReviewPrompt } = useAppReview();
 
 const props = defineProps<{
   donation: Donation;
@@ -131,6 +133,7 @@ const handleDonationConfirmation = async () => {
   updatingDonationStatus.value = true;
   try {
     await userStore.reviewDonation(props.donation, "confirmed");
+    scheduleReviewPrompt();
   } catch (error) {
     HemoNotification({
       type: "error",

--- a/composables/useAppReview.ts
+++ b/composables/useAppReview.ts
@@ -3,14 +3,16 @@ import { Preferences } from "@capacitor/preferences";
 
 const REVIEW_PREFERENCE_KEY = "lastAppReviewPromptTs";
 const SIX_MONTHS_MS = 6 * 30 * 24 * 60 * 60 * 1000;
+// Delay so the user sees the success state before the prompt appears.
+const REVIEW_PROMPT_DELAY_MS = 2000;
 
 /**
- * Composable to request an in-app review from the user.
+ * Composable to schedule an in-app review prompt.
  * The prompt is shown at most once every 6 months per device.
  * Only triggers on native platforms (iOS / Android).
  *
- * Usage: call `requestReview()` after a meaningful user action
- * (e.g. successfully registering a donation).
+ * Usage: call `scheduleReviewPrompt()` after a meaningful user action
+ * (e.g. successfully registering or confirming a donation).
  */
 export function useAppReview() {
   const requestReview = async () => {
@@ -43,5 +45,9 @@ export function useAppReview() {
     }
   };
 
-  return { requestReview };
+  const scheduleReviewPrompt = () => {
+    setTimeout(requestReview, REVIEW_PROMPT_DELAY_MS);
+  };
+
+  return { scheduleReviewPrompt };
 }

--- a/composables/useAppReview.ts
+++ b/composables/useAppReview.ts
@@ -1,0 +1,47 @@
+import { Capacitor } from "@capacitor/core";
+import { Preferences } from "@capacitor/preferences";
+
+const REVIEW_PREFERENCE_KEY = "lastAppReviewPromptTs";
+const SIX_MONTHS_MS = 6 * 30 * 24 * 60 * 60 * 1000;
+
+/**
+ * Composable to request an in-app review from the user.
+ * The prompt is shown at most once every 6 months per device.
+ * Only triggers on native platforms (iOS / Android).
+ *
+ * Usage: call `requestReview()` after a meaningful user action
+ * (e.g. successfully registering a donation).
+ */
+export function useAppReview() {
+  const requestReview = async () => {
+    // Only available on native platforms
+    if (!Capacitor.isNativePlatform()) return;
+
+    try {
+      const { value } = await Preferences.get({ key: REVIEW_PREFERENCE_KEY });
+
+      if (value) {
+        const lastPromptTs = parseInt(value, 10);
+        const sixMonthsAgo = Date.now() - SIX_MONTHS_MS;
+
+        // Don't show if prompted within the last 6 months
+        if (lastPromptTs > sixMonthsAgo) return;
+      }
+
+      // Lazy-load the plugin to avoid import errors on web
+      const { InAppReview } = await import("@capacitor-community/in-app-review");
+      await InAppReview.requestReview();
+
+      // Persist the timestamp so we don't prompt again too soon
+      await Preferences.set({
+        key: REVIEW_PREFERENCE_KEY,
+        value: Date.now().toString(),
+      });
+    } catch (error) {
+      // Review prompts are best-effort — never block the user flow
+      console.warn("[useAppReview] Failed to request review:", error);
+    }
+  };
+
+  return { requestReview };
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "capacitor:open:android": "npx cap open android"
   },
   "devDependencies": {
+    "@capacitor-community/in-app-review": "^7.1.0",
     "@capacitor/android": "^7.0.0",
     "@capacitor/app": "^7.0.0",
     "@capacitor/app-launcher": "^7.0.0",

--- a/pages/donations/mine/[id]/index.vue
+++ b/pages/donations/mine/[id]/index.vue
@@ -369,6 +369,7 @@ const route = useRoute();
 const donationId = parseInt(String(route.params.id));
 const userStore = useUserStore();
 const bloodBankStore = useBloodBanksStore();
+const { scheduleReviewPrompt } = useAppReview();
 const bloodBank = ref<BloodBankLocation | undefined>();
 const donation = ref(userStore.getDonationById(donationId));
 const updatingDonationStatus = ref(false);
@@ -431,6 +432,7 @@ const handleDonationConfirmation = async () => {
     await userStore.reviewDonation(donation.value, "confirmed");
     HemoMessage({ type: "success", message: "Doação confirmada com sucesso!" });
     showConfirmActionModal.value = false;
+    scheduleReviewPrompt();
   } catch (error) {
     HemoMessage({
       type: "error",

--- a/pages/donations/new.vue
+++ b/pages/donations/new.vue
@@ -89,8 +89,10 @@
 import { useUserStore } from "@/stores/user";
 import { useBloodBanksStore } from "@/stores/bloodBanks";
 import { ref, reactive, computed } from "vue";
+import { useAppReview } from "@/composables/useAppReview";
 
 const userStore = useUserStore();
+const { requestReview } = useAppReview();
 const userName = userStore.userWithMetrics!.name;
 const token = userStore.token!;
 const lastDonationBloodBankLocationId =
@@ -190,6 +192,8 @@ const submitForm = async () => {
   try {
     await userStore.createUserDonation(donationData);
     donationRegistered.value = true;
+    // Request in-app review after a short delay (let the user see the success state first)
+    setTimeout(requestReview, 2000);
   } catch (error) {
     let errorMessage =
       "Erro ao registrar doação. Por favor, tente novamente mais tarde.";

--- a/pages/donations/new.vue
+++ b/pages/donations/new.vue
@@ -92,7 +92,7 @@ import { ref, reactive, computed } from "vue";
 import { useAppReview } from "@/composables/useAppReview";
 
 const userStore = useUserStore();
-const { requestReview } = useAppReview();
+const { scheduleReviewPrompt } = useAppReview();
 const userName = userStore.userWithMetrics!.name;
 const token = userStore.token!;
 const lastDonationBloodBankLocationId =
@@ -192,8 +192,7 @@ const submitForm = async () => {
   try {
     await userStore.createUserDonation(donationData);
     donationRegistered.value = true;
-    // Request in-app review after a short delay (let the user see the success state first)
-    setTimeout(requestReview, 2000);
+    scheduleReviewPrompt();
   } catch (error) {
     let errorMessage =
       "Erro ao registrar doação. Por favor, tente novamente mais tarde.";

--- a/yarn.lock
+++ b/yarn.lock
@@ -231,6 +231,11 @@
     "@babel/helper-string-parser" "^7.25.9"
     "@babel/helper-validator-identifier" "^7.25.9"
 
+"@capacitor-community/in-app-review@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@capacitor-community/in-app-review/-/in-app-review-7.1.0.tgz"
+  integrity sha512-qB0Q+qvPxF03UWoryZubyMkOCRqJF5xEILjt+VC4768yyilyss4k6qDjT6x9x7T4T8o8kmGgbPBJgwf1fsLa1A==
+
 "@capacitor/android@^7.0.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@capacitor/android/-/android-7.2.0.tgz#f30e313315ab92c500bd57d9f0c4716a46b42f40"


### PR DESCRIPTION
## O que faz

Adiciona o prompt nativo de avaliação do app (App Store / Google Play) após o usuário registrar uma doação com sucesso.

## Como funciona

1. Usuário registra uma doação → vê a tela de sucesso ✅
2. Após 2 segundos, o composable verifica:
   - O usuário está em plataforma nativa (iOS/Android)?
   - Já faz mais de 6 meses desde o último prompt?
3. Se sim para ambos → dispara `InAppReview.requestReview()`
4. A data do prompt é salva em `@capacitor/preferences` para o controle de frequência

## Arquivos alterados

- `composables/useAppReview.ts` ← novo composable com toda a lógica
- `pages/donations/new.vue` ← chama `requestReview()` após doação registrada
- `package.json` ← adiciona `@capacitor-community/in-app-review@^7.1.0`
- `yarn.lock` ← atualizado

## Detalhes técnicos

- **Plugin:** `@capacitor-community/in-app-review@^7.1.0` (compatível com Capacitor 7)
- **Cooldown:** 6 meses por dispositivo (salvo em `@capacitor/preferences`)
- **Plataforma:** só executa em native (`Capacitor.isNativePlatform()`), silenciosamente ignorado no web
- **Lazy import:** plugin carregado dinamicamente para evitar erros de import no browser
- **Fail-safe:** qualquer erro é capturado silenciosamente — nunca bloqueia o fluxo do usuário
- **Delay de 2s:** o usuário vê a animação de sucesso antes do prompt aparecer

## Notas

- iOS e Android tratam o timing/frequência do prompt de forma diferente (o SO pode suprimir conforme políticas da loja). O `requestReview()` é uma **sugestão** — a exibição efetiva é controlada pela plataforma.
- Recomendado executar `yarn install` e `cap sync` após merge para sincronizar os plugins nativos.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an in-app review prompt shown after successful donations.
  * Prompt is delayed briefly to avoid interrupting flow, runs only on native mobile platforms, and is limited to once per device every six months.
  * Review attempts run non-blocking and will not disrupt the user experience if unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->